### PR TITLE
[#10] Remove trailing '. Wikipedia' from speech results.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,10 @@ AlexaGoogleSearch.prototype.intentHandlers = {
               cardOutputText = cardOutputText.split('SHORTALEXAPAUSE').join('') // remove pauses from card text
               cardOutputText = cardOutputText.split('ALEXAPAUSE').join('\r\n') // remove pauses from card text
 
+            // strip trailing 'Wikipedia' from the end of speech output (addresses #10)
+            speechOutputTemp = speechOutputTemp.replace(/. Wikipedia\b/g, '.') // Remove Wikipedia from the end of a string (when it is after a full stop)
+            cardOutputText = cardOutputText.replace(/. Wikipedia\b/g, '.')
+
 			speechOutputTemp = speechOutputTemp.split('.').join(". ") // Assume any remaining dot are concatonated sentances so turn them into full stops with a pause afterwards
 			var speechOutput = speechOutputTemp.replace(/DECIMALPOINT/g,'.') // Put back decimal points
             


### PR DESCRIPTION
When a result is sourced from Wikipedia, the card has a trailing ' Wikipedia' which, as is mentioned in #10 ruins the effect.

This simple addition strips any '. Wikipedia' text from the end of a result. If Wikipedia was the last word of a result it would be ' Wikipedia.' which breaks the regex check.

This commit also includes an updated (and initially tested) `Archive.zip`. Although I haven't exhaustively tested each feature in the script, I have confirmed that this does infact remove 'Wikipedia' as expected.

A simple test for this is:
```
Alexa, Ask Google who is Barack Obama?
```

You will be able to see that the trailing 'Wikipedia' is removed with this update.