### PR TITLE
[#10] Remove trailing '. Wikipedia' from speech results. (Version 2 update)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,8 +151,10 @@ AlexaGoogleSearch.prototype.intentHandlers = {
             speechOutputTemp = speechOutputTemp.replace(/</g, localeResponse[6]); // replace < symbol 
             speechOutputTemp = speechOutputTemp.replace(/""/g, ''); // replace double quotes 
 
-            
-            
+            // Addresses #10 - stripping 'Wikipedia' from the end of result text
+            speechOutputTemp = speechOutputTemp.replace(/. Wikipedia\b/g, '.');
+            cardOutputText   = cardOutputText.replace(/. Wikipedia\b/g, '.');
+
             // Add in SSML pauses
             speechOutputTemp = speechOutputTemp.replace(/SHORTALEXAPAUSERTN/g, '<break time=\"250ms\"/>'); // add in SSML pauses at table ends 
             speechOutputTemp = speechOutputTemp.replace(/SHORTALEXAPAUSE/g, '<break time=\"250ms\"/>'); // add in SSML pauses at table ends


### PR DESCRIPTION
When a result is sourced from Wikipedia, the card has a trailing ' Wikipedia' which, as is mentioned in #10 ruins the effect.

This simple addition strips any '. Wikipedia' text from the end of a result. If Wikipedia was the last word of a result it would be ' Wikipedia.' which breaks the regex check.

This commit also includes an updated (and initially tested) `Archive.zip`. Although I haven't exhaustively tested each feature in the script, I have confirmed that this does infact remove 'Wikipedia' as expected.

A simple test for this is:
```
Alexa, Ask Google who is Barack Obama?
```

You will be able to see that the trailing 'Wikipedia' is removed with this update.